### PR TITLE
Add multi-mode gameplay with online support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Aplicación de Tic-Tac-Toe creada con React y Vite que ahora admite tres modos d
 
 ## Requisitos
 
-- Node.js 18 o superior
+- Node.js 20 o superior (LTS)
 
 ## Instalación
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,48 @@
-# React + Vite
+# Ares Tac Toe
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Aplicación de Tic-Tac-Toe creada con React y Vite que ahora admite tres modos de juego:
 
-Currently, two official plugins are available:
+- **Juego local** en el mismo dispositivo.
+- **Modo solo** contra un bot con inteligencia básica basada en *minimax*.
+- **Juego online** mediante salas privadas protegidas con código y contraseña, sincronizadas con WebSockets.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Requisitos
+
+- Node.js 18 o superior
+
+## Instalación
+
+```bash
+npm install
+```
+
+## Scripts disponibles
+
+- `npm run dev`: inicia el cliente de Vite en modo desarrollo.
+- `npm run build`: genera la versión optimizada para producción.
+- `npm run preview`: ejecuta la vista previa del build.
+- `npm run server`: levanta el servidor WebSocket necesario para las partidas online.
+
+## Juego online
+
+1. Ejecutá el servidor WebSocket en una terminal:
+   ```bash
+   npm run server
+   ```
+2. En otra terminal, iniciá la aplicación web:
+   ```bash
+   npm run dev
+   ```
+3. Abrí `http://localhost:5173` en tu navegador. En la pantalla de inicio elegí "Juego Online".
+4. Ingresá tu nombre de usuario, luego seleccioná si querés crear o unirte a una sala.
+5. Al crear o unirte se te pedirá un **código** y una **contraseña**. Ambos datos son necesarios tanto para el host como para la persona invitada.
+
+> 💡 Podés cambiar la URL del WebSocket estableciendo la variable de entorno `VITE_WS_URL` antes de arrancar el cliente. Por defecto se conecta a `ws://localhost:3001`.
+
+## Juego contra el bot
+
+El modo "Jugar Solo" utiliza un bot determinista que analiza todas las combinaciones posibles para ofrecer partidas desafiantes. Tras cada encuentro podés reiniciar la partida y volver al inicio cuando quieras.
+
+## Licencia
+
+Proyecto con fines educativos.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "ares-tac-toe",
       "version": "0.0.0",
+      "engines": {
+        "node": ">=20.11.0"
+      },
       "dependencies": {
         "canvas-confetti": "^1.9.2",
         "prop-types": "^15.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "canvas-confetti": "^1.9.2",
+        "prop-types": "^15.8.1",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "ws": "^8.18.3"
       },
       "devDependencies": {
         "@types/react": "^18.2.43",
@@ -2569,7 +2571,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2819,7 +2820,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -2881,8 +2882,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
@@ -3535,6 +3535,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,15 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "canvas-confetti": "^1.9.2",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "ws": "^8.18.3"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20.11.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,312 @@
+/* eslint-env node */
+import { randomUUID } from "crypto";
+import { WebSocketServer, WebSocket } from "ws";
+
+const PORT = Number(process.env.PORT ?? 3001);
+
+const winnerCombos = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8],
+  [0, 4, 8],
+  [2, 4, 6],
+];
+
+const createEmptyBoard = () => Array(9).fill(null);
+
+const checkWinner = (board) => {
+  for (const combo of winnerCombos) {
+    const [a, b, c] = combo;
+    if (board[a] && board[a] === board[b] && board[a] === board[c]) {
+      return board[a];
+    }
+  }
+  return null;
+};
+
+const isDraw = (board) => board.every((cell) => cell !== null);
+
+const getNextTurn = (turn) => (turn === "X" ? "O" : "X");
+
+const rooms = new Map();
+
+const getPlayersInfo = (room) =>
+  Array.from(room.players.values()).map(({ username, symbol }) => ({
+    username,
+    symbol,
+  }));
+
+const broadcast = (room, message, excludeId = null) => {
+  const data = JSON.stringify(message);
+  room.players.forEach((player, id) => {
+    if (excludeId && id === excludeId) return;
+    if (player.ws.readyState === WebSocket.OPEN) {
+      player.ws.send(data);
+    }
+  });
+};
+
+const server = new WebSocketServer({ port: PORT });
+
+console.log(`WebSocket listening on ws://localhost:${PORT}`);
+
+server.on("connection", (ws) => {
+  const clientId = randomUUID();
+  let currentRoomCode = null;
+
+  const send = (type, payload = {}) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type, payload }));
+    }
+  };
+
+  const leaveCurrentRoom = (reason = "disconnect") => {
+    if (!currentRoomCode) return;
+    const room = rooms.get(currentRoomCode);
+    if (!room) {
+      currentRoomCode = null;
+      return;
+    }
+
+    const player = room.players.get(clientId);
+    room.players.delete(clientId);
+
+    if (room.players.size === 0) {
+      rooms.delete(currentRoomCode);
+    } else {
+      room.board = createEmptyBoard();
+      room.turn = "X";
+      room.winner = null;
+      broadcast(room, {
+        type: "player_left",
+        payload: {
+          username: player?.username ?? "Jugador",
+          players: getPlayersInfo(room),
+          board: room.board,
+          turn: room.turn,
+          reason,
+        },
+      });
+    }
+
+    currentRoomCode = null;
+  };
+
+  ws.on("message", (rawMessage) => {
+    let data;
+    try {
+      data = JSON.parse(rawMessage.toString());
+    } catch (error) {
+      send("error", { message: "Mensaje inválido." });
+      return;
+    }
+
+    const { type, payload } = data;
+
+    switch (type) {
+      case "create_room": {
+        leaveCurrentRoom("replace");
+        const code = String(payload?.code ?? "").trim().toUpperCase();
+        const password = String(payload?.password ?? "").trim();
+        const username = String(payload?.username ?? "").trim();
+
+        if (!code || !password || !username) {
+          send("error", { message: "Código, contraseña y nombre son obligatorios." });
+          return;
+        }
+
+        const existingRoom = rooms.get(code);
+        if (existingRoom && existingRoom.players.size > 0) {
+          send("error", { message: "Ya existe una sala activa con ese código." });
+          return;
+        }
+
+        const room = {
+          code,
+          password,
+          board: createEmptyBoard(),
+          turn: "X",
+          winner: null,
+          players: new Map(),
+        };
+
+        rooms.set(code, room);
+
+        const playerData = {
+          id: clientId,
+          ws,
+          username,
+          symbol: "X",
+        };
+
+        room.players.set(clientId, playerData);
+        currentRoomCode = code;
+
+        send("room_created", {
+          code,
+          symbol: playerData.symbol,
+          board: room.board,
+          turn: room.turn,
+          players: getPlayersInfo(room),
+        });
+        break;
+      }
+
+      case "join_room": {
+        leaveCurrentRoom("replace");
+        const code = String(payload?.code ?? "").trim().toUpperCase();
+        const password = String(payload?.password ?? "").trim();
+        const username = String(payload?.username ?? "").trim();
+
+        if (!code || !password || !username) {
+          send("error", { message: "Código, contraseña y nombre son obligatorios." });
+          return;
+        }
+
+        const room = rooms.get(code);
+        if (!room) {
+          send("error", { message: "No existe una sala con ese código." });
+          return;
+        }
+
+        if (room.password !== password) {
+          send("error", { message: "Contraseña incorrecta." });
+          return;
+        }
+
+        if (room.players.size >= 2) {
+          send("error", { message: "La sala ya está completa." });
+          return;
+        }
+
+        const symbol = room.players.size === 0 ? "X" : "O";
+        const playerData = {
+          id: clientId,
+          ws,
+          username,
+          symbol,
+        };
+
+        room.players.set(clientId, playerData);
+        currentRoomCode = code;
+
+        send("room_joined", {
+          code,
+          symbol,
+          board: room.board,
+          turn: room.turn,
+          players: getPlayersInfo(room),
+        });
+
+        broadcast(
+          room,
+          {
+            type: "player_joined",
+            payload: {
+              username,
+              players: getPlayersInfo(room),
+            },
+          },
+          clientId,
+        );
+        break;
+      }
+
+      case "make_move": {
+        if (currentRoomCode === null) {
+          send("error", { message: "No estás en una sala." });
+          return;
+        }
+
+        const room = rooms.get(currentRoomCode);
+        if (!room) {
+          send("error", { message: "La sala ya no está disponible." });
+          return;
+        }
+
+        const player = room.players.get(clientId);
+        if (!player) {
+          send("error", { message: "No estás en esta sala." });
+          return;
+        }
+
+        const index = Number(payload?.index);
+        if (!Number.isInteger(index) || index < 0 || index > 8) {
+          send("error", { message: "Movimiento inválido." });
+          return;
+        }
+
+        if (room.winner) {
+          return;
+        }
+
+        if (room.board[index] !== null) {
+          return;
+        }
+
+        if (player.symbol !== room.turn) {
+          send("error", { message: "No es tu turno." });
+          return;
+        }
+
+        room.board[index] = player.symbol;
+        const winner = checkWinner(room.board);
+
+        if (winner) {
+          room.winner = winner;
+          room.turn = getNextTurn(player.symbol);
+        } else if (isDraw(room.board)) {
+          room.winner = "draw";
+          room.turn = getNextTurn(player.symbol);
+        } else {
+          room.turn = getNextTurn(room.turn);
+        }
+
+        broadcast(room, {
+          type: "game_state",
+          payload: {
+            board: room.board,
+            turn: room.turn,
+            winner: room.winner,
+          },
+        });
+        break;
+      }
+
+      case "reset_game": {
+        if (currentRoomCode === null) return;
+        const room = rooms.get(currentRoomCode);
+        if (!room) return;
+
+        room.board = createEmptyBoard();
+        room.turn = "X";
+        room.winner = null;
+
+        broadcast(room, {
+          type: "game_state",
+          payload: {
+            board: room.board,
+            turn: room.turn,
+            winner: room.winner,
+          },
+        });
+        break;
+      }
+
+      case "leave_room": {
+        leaveCurrentRoom("leave");
+        break;
+      }
+
+      default:
+        send("error", { message: "Acción no reconocida." });
+    }
+  });
+
+  ws.on("close", () => {
+    leaveCurrentRoom("disconnect");
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -257,10 +257,10 @@ server.on("connection", (ws) => {
 
         if (winner) {
           room.winner = winner;
-          room.turn = getNextTurn(player.symbol);
+          room.turn = null;
         } else if (isDraw(room.board)) {
           room.winner = "draw";
-          room.turn = getNextTurn(player.symbol);
+          room.turn = null;
         } else {
           room.turn = getNextTurn(room.turn);
         }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,113 +1,30 @@
 import { useState } from "react";
-import { Square } from "./components/square";
-import { TURNS, winnerCombos } from "./components/constants.js";
+import { BotGame } from "./components/BotGame";
+import { HomeScreen } from "./components/HomeScreen";
+import { OfflineGame } from "./components/OfflineGame";
+import { OnlineGame } from "./components/OnlineGame";
 import { Footer } from "./components/links.jsx";
-//!
-import confetti from "canvas-confetti";
-import logo from "./assets/logo.svg";
-//!
+
+const MODES = {
+  HOME: "home",
+  OFFLINE: "offline",
+  ONLINE: "online",
+  BOT: "bot",
+};
 
 function App() {
-  const [board, setBoard] = useState(() => {
-    const boardFromStorage = window.localStorage.getItem("board");
-    if (boardFromStorage) return JSON.parse(boardFromStorage);
-    return Array(9).fill(null);
-  });
+  const [mode, setMode] = useState(MODES.HOME);
 
-  const [turn, setTurn] = useState(() => {
-    const turnFromStorage = window.localStorage.getItem("turn");
-    return turnFromStorage ?? TURNS.X;
-  });
-
-  const [winner, setWinner] = useState(null);
-
-  const checkWinner = (boardToCheck) => {
-    for (const combo of winnerCombos) {
-      const [a, b, c] = combo;
-      if (
-        boardToCheck[a] &&
-        boardToCheck[a] === boardToCheck[b] &&
-        boardToCheck[a] === boardToCheck[c]
-      ) {
-        return boardToCheck[a];
-      }
-    }
-    return null;
-  };
-
-  const resetGame = () => {
-    setBoard(Array(9).fill(null));
-    setTurn(winner === TURNS.X ? TURNS.O : TURNS.X);
-    setWinner(null);
-
-    window.localStorage.removeItem("board");
-    window.localStorage.removeItem("turn");
-  };
-
-  const checkEndGame = (newBoard) => {
-    return newBoard.every((square) => square !== null);
-  };
-
-  const updateBoard = (index) => {
-    if (board[index] || winner) return;
-
-    const newBoard = [...board];
-    newBoard[index] = turn;
-    setBoard(newBoard);
-
-    const newTurn = turn === TURNS.X ? TURNS.O : TURNS.X;
-    setTurn(newTurn);
-
-    window.localStorage.setItem("board", JSON.stringify(newBoard));
-    window.localStorage.setItem("turn", newTurn);
-
-    const newWinner = checkWinner(newBoard);
-    if (newWinner) {
-      confetti();
-      setWinner(newWinner);
-    } else if (checkEndGame(newBoard)) {
-      setWinner(false);
-    }
+  const handleGoHome = () => {
+    setMode(MODES.HOME);
   };
 
   return (
-    <main className="board">
-      <h1>
-        <img src={logo} width={50} />
-        Ares Tac Toe
-      </h1>
-
-      <button onClick={resetGame}>Reset Game</button>
-      <section className="game">
-        {board.map((square, index) => {
-          return (
-            <Square key={index} index={index} updateBoard={updateBoard}>
-              {square}
-            </Square>
-          );
-        })}
-      </section>
-
-      <section className="turn">
-        <Square isSelected={turn === TURNS.X}>{TURNS.X}</Square>
-        <Square isSelected={turn === TURNS.O}>{TURNS.O}</Square>
-      </section>
-
-      {winner !== null && (
-        <section className="winner">
-          <div className="text">
-            <h2>{winner === false ? "Draw" : "Winner:"}</h2>
-
-            <header className="win">
-              {winner && <Square>{winner}</Square>}
-            </header>
-
-            <footer>
-              <button onClick={resetGame}>Restart Game</button>
-            </footer>
-          </div>
-        </section>
-      )}
+    <main className="app-shell">
+      {mode === MODES.HOME && <HomeScreen onSelectMode={setMode} />}
+      {mode === MODES.OFFLINE && <OfflineGame onGoHome={handleGoHome} />}
+      {mode === MODES.ONLINE && <OnlineGame onGoHome={handleGoHome} />}
+      {mode === MODES.BOT && <BotGame onGoHome={handleGoHome} />}
       <Footer />
     </main>
   );

--- a/src/components/BotGame.jsx
+++ b/src/components/BotGame.jsx
@@ -1,0 +1,205 @@
+import PropTypes from "prop-types";
+import { useEffect, useMemo, useState } from "react";
+import confetti from "canvas-confetti";
+import {
+  TURNS,
+  TURN_ICONS,
+  checkEndGame,
+  checkWinner,
+  createEmptyBoard,
+  getIconForValue,
+  getNextTurn,
+} from "./constants";
+import { Square } from "./square";
+
+const BOT_DELAY = 600;
+const HUMAN = TURNS.X;
+const BOT = TURNS.O;
+
+const minimax = (board, depth, isMaximizing, botSymbol, humanSymbol) => {
+  const winner = checkWinner(board);
+  if (winner === botSymbol) return 10 - depth;
+  if (winner === humanSymbol) return depth - 10;
+  if (checkEndGame(board)) return 0;
+
+  if (isMaximizing) {
+    let bestScore = -Infinity;
+    for (let i = 0; i < board.length; i += 1) {
+      if (board[i]) continue;
+      board[i] = botSymbol;
+      const score = minimax(board, depth + 1, false, botSymbol, humanSymbol);
+      board[i] = null;
+      bestScore = Math.max(bestScore, score);
+    }
+    return bestScore;
+  }
+
+  let bestScore = Infinity;
+  for (let i = 0; i < board.length; i += 1) {
+    if (board[i]) continue;
+    board[i] = humanSymbol;
+    const score = minimax(board, depth + 1, true, botSymbol, humanSymbol);
+    board[i] = null;
+    bestScore = Math.min(bestScore, score);
+  }
+  return bestScore;
+};
+
+const getBestMove = (board, botSymbol, humanSymbol) => {
+  let bestScore = -Infinity;
+  let move = null;
+  for (let i = 0; i < board.length; i += 1) {
+    if (board[i]) continue;
+    board[i] = botSymbol;
+    const score = minimax(board, 0, false, botSymbol, humanSymbol);
+    board[i] = null;
+    if (score > bestScore) {
+      bestScore = score;
+      move = i;
+    }
+  }
+  return move;
+};
+
+export function BotGame({ onGoHome }) {
+  const [board, setBoard] = useState(createEmptyBoard);
+  const [turn, setTurn] = useState(TURNS.X);
+  const [winner, setWinner] = useState(null);
+  const [isBotThinking, setIsBotThinking] = useState(false);
+
+  const isPlayerTurn = useMemo(
+    () => turn === HUMAN && winner === null,
+    [turn, winner],
+  );
+
+  const commitMove = (boardAfterMove, currentSymbol) => {
+    const moveWinner = checkWinner(boardAfterMove);
+    const draw = !moveWinner && checkEndGame(boardAfterMove);
+    const nextTurn = getNextTurn(currentSymbol);
+
+    if (moveWinner) {
+      confetti();
+      setWinner(moveWinner);
+    } else if (draw) {
+      setWinner("draw");
+    }
+
+    setBoard(boardAfterMove);
+    setTurn(nextTurn);
+  };
+
+  const handlePlayerMove = (index) => {
+    if (!isPlayerTurn || board[index]) return;
+    const newBoard = [...board];
+    newBoard[index] = HUMAN;
+    commitMove(newBoard, HUMAN);
+  };
+
+  useEffect(() => {
+    if (winner || turn !== BOT) return;
+
+    setIsBotThinking(true);
+    const timeout = setTimeout(() => {
+      const boardCopy = [...board];
+      const bestMove = getBestMove(boardCopy, BOT, HUMAN);
+      if (bestMove !== null && boardCopy[bestMove] === null) {
+        boardCopy[bestMove] = BOT;
+        commitMove(boardCopy, BOT);
+      }
+      setIsBotThinking(false);
+    }, BOT_DELAY);
+
+    return () => {
+      clearTimeout(timeout);
+      setIsBotThinking(false);
+    };
+  }, [board, winner, turn]);
+
+  const resetGame = () => {
+    setBoard(createEmptyBoard());
+    setTurn(TURNS.X);
+    setWinner(null);
+    setIsBotThinking(false);
+  };
+
+  return (
+    <section className="board">
+      <header className="board-header">
+        <button type="button" onClick={onGoHome} className="secondary-button">
+          Volver al inicio
+        </button>
+        <h2>Modo Solo</h2>
+      </header>
+
+      <div className="status-message">
+        {winner === null
+          ? isPlayerTurn
+            ? "Es tu turno"
+            : isBotThinking
+              ? "El bot está pensando..."
+              : "Esperando al bot"
+          : winner === "draw"
+            ? "¡Empate!"
+            : winner === HUMAN
+              ? "¡Ganaste!"
+              : "El bot ganó"}
+      </div>
+
+      <button onClick={resetGame} type="button">
+        Reiniciar partida
+      </button>
+
+      <section className="game">
+        {board.map((square, index) => (
+          <Square
+            key={index}
+            index={index}
+            updateBoard={handlePlayerMove}
+            disabled={!isPlayerTurn}
+          >
+            {getIconForValue(square)}
+          </Square>
+        ))}
+      </section>
+
+      <section className="turn">
+        <Square isSelected={turn === HUMAN} disabled>
+          {TURN_ICONS[HUMAN]}
+        </Square>
+        <Square isSelected={turn === BOT} disabled>
+          {TURN_ICONS[BOT]}
+        </Square>
+      </section>
+
+      {winner !== null && (
+        <section className="winner">
+          <div className="text">
+            <h2>
+              {winner === "draw"
+                ? "¡Empate!"
+                : winner === HUMAN
+                  ? "¡Felicitaciones!"
+                  : "El bot ganó"}
+            </h2>
+
+            <header className="win">
+              {winner !== "draw" && (
+                <Square disabled>{getIconForValue(winner)}</Square>
+              )}
+            </header>
+
+            <footer>
+              <button onClick={resetGame} type="button">
+                Jugar de nuevo
+              </button>
+            </footer>
+          </div>
+        </section>
+      )}
+    </section>
+  );
+}
+
+BotGame.propTypes = {
+  onGoHome: PropTypes.func.isRequired,
+};

--- a/src/components/HomeScreen.jsx
+++ b/src/components/HomeScreen.jsx
@@ -1,0 +1,61 @@
+import PropTypes from "prop-types";
+import logo from "../assets/logo.svg";
+import { TURN_ICONS } from "./constants";
+
+const modeDescriptions = {
+  offline: "Juega con un amigo en el mismo dispositivo.",
+  online: "Creá o unite a una sala privada y enfrentate online.",
+  bot: "Practica contra el bot inteligente para mejorar tus jugadas.",
+};
+
+export function HomeScreen({ onSelectMode }) {
+  return (
+    <section className="home-screen">
+      <img src={logo} width={80} alt="Ares Tac Toe" className="home-logo" />
+      <h1>Ares Tac Toe</h1>
+      <p className="home-subtitle">
+        Elegí cómo querés jugar: local, contra la IA o mediante salas online
+        protegidas con contraseña.
+      </p>
+
+      <div className="mode-buttons">
+        <button
+          type="button"
+          onClick={() => onSelectMode("offline")}
+          className="mode-button"
+        >
+          <span className="mode-title">Juego Local</span>
+          <span className="mode-description">{modeDescriptions.offline}</span>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => onSelectMode("online")}
+          className="mode-button"
+        >
+          <span className="mode-title">Juego Online</span>
+          <span className="mode-description">{modeDescriptions.online}</span>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => onSelectMode("bot")}
+          className="mode-button"
+        >
+          <span className="mode-title">Jugar Solo</span>
+          <span className="mode-description">{modeDescriptions.bot}</span>
+        </button>
+      </div>
+
+      <div className="home-icons" aria-hidden>
+        <span>{TURN_ICONS.X}</span>
+        <span>vs</span>
+        <span>{TURN_ICONS.O}</span>
+      </div>
+    </section>
+  );
+}
+
+HomeScreen.propTypes = {
+  onSelectMode: PropTypes.func.isRequired,
+};

--- a/src/components/OfflineGame.jsx
+++ b/src/components/OfflineGame.jsx
@@ -1,0 +1,158 @@
+import PropTypes from "prop-types";
+import { useMemo, useState } from "react";
+import confetti from "canvas-confetti";
+import {
+  TURNS,
+  TURN_ICONS,
+  checkEndGame,
+  checkWinner,
+  createEmptyBoard,
+  getIconForValue,
+  getNextTurn,
+} from "./constants";
+import { Square } from "./square";
+
+const BOARD_STORAGE_KEY = "offline-board";
+const TURN_STORAGE_KEY = "offline-turn";
+
+const normalizeStoredValue = (value) => {
+  if (value === TURN_ICONS[TURNS.X]) return TURNS.X;
+  if (value === TURN_ICONS[TURNS.O]) return TURNS.O;
+  if (value === TURNS.X || value === TURNS.O) return value;
+  return null;
+};
+
+const readStoredBoard = () => {
+  if (typeof window === "undefined") return createEmptyBoard();
+  const raw = window.localStorage.getItem(BOARD_STORAGE_KEY);
+  if (!raw) return createEmptyBoard();
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.length === 9) {
+      return parsed.map((cell) => normalizeStoredValue(cell));
+    }
+  } catch (error) {
+    console.error("Error parsing stored board", error);
+  }
+  return createEmptyBoard();
+};
+
+const readStoredTurn = () => {
+  if (typeof window === "undefined") return TURNS.X;
+  const raw = window.localStorage.getItem(TURN_STORAGE_KEY);
+  return normalizeStoredValue(raw) ?? TURNS.X;
+};
+
+const persistState = (board, turn) => {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(BOARD_STORAGE_KEY, JSON.stringify(board));
+  window.localStorage.setItem(TURN_STORAGE_KEY, turn);
+};
+
+export function OfflineGame({ onGoHome }) {
+  const [board, setBoard] = useState(readStoredBoard);
+  const [turn, setTurn] = useState(readStoredTurn);
+  const [winner, setWinner] = useState(null);
+
+  const isBoardDisabled = useMemo(() => winner !== null, [winner]);
+
+  const resetGame = () => {
+    const nextTurn =
+      winner && winner !== "draw"
+        ? winner === TURNS.X
+          ? TURNS.O
+          : TURNS.X
+        : TURNS.X;
+
+    const freshBoard = createEmptyBoard();
+    setBoard(freshBoard);
+    setTurn(nextTurn);
+    setWinner(null);
+    persistState(freshBoard, nextTurn);
+  };
+
+  const updateBoard = (index) => {
+    if (board[index] || winner) return;
+
+    const newBoard = [...board];
+    newBoard[index] = turn;
+    setBoard(newBoard);
+
+    const newWinner = checkWinner(newBoard);
+    const isDraw = !newWinner && checkEndGame(newBoard);
+    const nextTurn = getNextTurn(turn);
+
+    if (newWinner) {
+      confetti();
+      setWinner(newWinner);
+    } else if (isDraw) {
+      setWinner("draw");
+    }
+
+    setTurn(nextTurn);
+    persistState(newBoard, nextTurn);
+  };
+
+  return (
+    <section className="board">
+      <header className="board-header">
+        <button type="button" onClick={onGoHome} className="secondary-button">
+          Volver al inicio
+        </button>
+        <h2>Juego local</h2>
+      </header>
+
+      <button onClick={resetGame} type="button">
+        Reiniciar partida
+      </button>
+
+      <section className="game">
+        {board.map((square, index) => (
+          <Square
+            key={index}
+            index={index}
+            updateBoard={updateBoard}
+            disabled={isBoardDisabled}
+          >
+            {getIconForValue(square)}
+          </Square>
+        ))}
+      </section>
+
+      <section className="turn">
+        <Square isSelected={turn === TURNS.X} disabled>
+          {TURN_ICONS[TURNS.X]}
+        </Square>
+        <Square isSelected={turn === TURNS.O} disabled>
+          {TURN_ICONS[TURNS.O]}
+        </Square>
+      </section>
+
+      {winner !== null && (
+        <section className="winner">
+          <div className="text">
+            <h2>
+              {winner === "draw" ? "¡Empate!" : "Ganador:"}
+            </h2>
+
+            <header className="win">
+              {winner !== "draw" && (
+                <Square disabled>{getIconForValue(winner)}</Square>
+              )}
+            </header>
+
+            <footer>
+              <button onClick={resetGame} type="button">
+                Jugar de nuevo
+              </button>
+            </footer>
+          </div>
+        </section>
+      )}
+    </section>
+  );
+}
+
+OfflineGame.propTypes = {
+  onGoHome: PropTypes.func.isRequired,
+};

--- a/src/components/OnlineGame.jsx
+++ b/src/components/OnlineGame.jsx
@@ -1,0 +1,456 @@
+import PropTypes from "prop-types";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import confetti from "canvas-confetti";
+import { TURNS, TURN_ICONS, createEmptyBoard, getIconForValue } from "./constants";
+import { Square } from "./square";
+
+const STEPS = {
+  USERNAME: "username",
+  MODE: "mode",
+  ROOM: "room",
+  WAITING: "waiting",
+  PLAYING: "playing",
+};
+
+const WS_URL = import.meta.env.VITE_WS_URL ?? "ws://localhost:3001";
+
+const createInitialState = () => ({
+  board: createEmptyBoard(),
+  turn: TURNS.X,
+  winner: null,
+});
+
+export function OnlineGame({ onGoHome }) {
+  const [step, setStep] = useState(STEPS.USERNAME);
+  const [username, setUsername] = useState("");
+  const [action, setAction] = useState(null);
+  const [roomCode, setRoomCode] = useState("");
+  const [password, setPassword] = useState("");
+  const [playerSymbol, setPlayerSymbol] = useState(null);
+  const [gameState, setGameState] = useState(createInitialState);
+  const [statusMessage, setStatusMessage] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [players, setPlayers] = useState([]);
+  const [opponentName, setOpponentName] = useState("");
+  const [connectionState, setConnectionState] = useState("disconnected");
+
+  const socketRef = useRef(null);
+  const playerSymbolRef = useRef(null);
+  const stepRef = useRef(STEPS.USERNAME);
+
+  const updateStep = useCallback((newStep) => {
+    stepRef.current = newStep;
+    setStep(newStep);
+  }, []);
+
+  const resetLocalState = useCallback(() => {
+    setGameState(createInitialState());
+    setPlayerSymbol(null);
+    playerSymbolRef.current = null;
+    setStatusMessage("");
+    setPlayers([]);
+    setOpponentName("");
+  }, []);
+
+  const cleanupConnection = useCallback(() => {
+    const socket = socketRef.current;
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.close();
+    }
+    socketRef.current = null;
+    setConnectionState("disconnected");
+  }, []);
+
+  useEffect(() => () => cleanupConnection(), [cleanupConnection]);
+
+  const sendMessage = useCallback((type, payload = {}) => {
+    const socket = socketRef.current;
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ type, payload }));
+    }
+  }, []);
+
+  const handleServerMessage = useCallback(
+    (event) => {
+      let data;
+      try {
+        data = JSON.parse(event.data);
+      } catch (error) {
+        console.error("Mensaje de servidor inválido", error);
+        return;
+      }
+
+      const { type, payload } = data;
+
+      switch (type) {
+        case "error":
+          setErrorMessage(payload?.message ?? "Ocurrió un error.");
+          if (payload?.reset) {
+            resetLocalState();
+            updateStep(STEPS.MODE);
+          }
+          break;
+        case "room_created": {
+          const roomBoard = payload?.board ?? createEmptyBoard();
+          const roomTurn = payload?.turn ?? TURNS.X;
+          const symbol = payload?.symbol ?? TURNS.X;
+          const currentPlayers = payload?.players ?? [];
+
+          playerSymbolRef.current = symbol;
+          setPlayerSymbol(symbol);
+          setGameState({ board: roomBoard, turn: roomTurn, winner: null });
+          setPlayers(currentPlayers);
+          setStatusMessage(
+            "Sala creada. Compartí el código y la contraseña para invitar a alguien.",
+          );
+          updateStep(STEPS.WAITING);
+          break;
+        }
+        case "room_joined": {
+          const roomBoard = payload?.board ?? createEmptyBoard();
+          const roomTurn = payload?.turn ?? TURNS.X;
+          const symbol = payload?.symbol ?? TURNS.O;
+          const currentPlayers = payload?.players ?? [];
+
+          playerSymbolRef.current = symbol;
+          setPlayerSymbol(symbol);
+          setGameState({ board: roomBoard, turn: roomTurn, winner: null });
+          setPlayers(currentPlayers);
+          const opponent = currentPlayers.find((player) => player.symbol !== symbol);
+          setOpponentName(opponent?.username ?? "");
+          setStatusMessage("Te uniste a la sala. ¡A jugar!");
+          updateStep(STEPS.PLAYING);
+          break;
+        }
+        case "player_joined": {
+          const currentPlayers = payload?.players ?? [];
+          setPlayers(currentPlayers);
+          const symbol = playerSymbolRef.current;
+          const opponent = currentPlayers.find((player) => player.symbol !== symbol);
+          setOpponentName(opponent?.username ?? "");
+          setStatusMessage(`${payload?.username ?? "Un jugador"} se unió a la sala.`);
+          if (stepRef.current === STEPS.WAITING) {
+            updateStep(STEPS.PLAYING);
+          }
+          break;
+        }
+        case "player_left": {
+          const currentPlayers = payload?.players ?? [];
+          setPlayers(currentPlayers);
+          setOpponentName("");
+          setStatusMessage(`${payload?.username ?? "Un jugador"} salió de la sala.`);
+          setGameState({
+            board: payload?.board ?? createEmptyBoard(),
+            turn: payload?.turn ?? TURNS.X,
+            winner: null,
+          });
+          updateStep(STEPS.WAITING);
+          break;
+        }
+        case "game_state": {
+          const winner = payload?.winner ?? null;
+          setGameState({
+            board: payload?.board ?? createEmptyBoard(),
+            turn: payload?.turn ?? TURNS.X,
+            winner,
+          });
+          if (winner && winner !== "draw" && winner === playerSymbolRef.current) {
+            confetti();
+          }
+          if (winner === "draw") {
+            setStatusMessage("La partida terminó en empate.");
+          } else if (winner) {
+            setStatusMessage(
+              winner === playerSymbolRef.current
+                ? "¡Ganaste la partida!"
+                : "Tu rival ganó la partida.",
+            );
+          } else {
+            setStatusMessage(
+              playerSymbolRef.current === payload?.turn
+                ? "Es tu turno."
+                : "Esperando al rival...",
+            );
+          }
+          break;
+        }
+        case "room_closed": {
+          setErrorMessage(payload?.message ?? "La sala se cerró.");
+          resetLocalState();
+          cleanupConnection();
+          updateStep(STEPS.MODE);
+          break;
+        }
+        default:
+          console.warn("Tipo de mensaje no soportado", type);
+      }
+    },
+    [cleanupConnection, resetLocalState, updateStep],
+  );
+
+  const handleConnect = useCallback(() => {
+    cleanupConnection();
+    setErrorMessage("");
+
+    const socket = new WebSocket(WS_URL);
+    socketRef.current = socket;
+    setConnectionState("connecting");
+    setStatusMessage("Conectando al servidor...");
+
+    socket.addEventListener("open", () => {
+      setConnectionState("connected");
+      const type = action === "create" ? "create_room" : "join_room";
+      socket.send(
+        JSON.stringify({
+          type,
+          payload: {
+            code: roomCode.trim(),
+            password: password.trim(),
+            username: username.trim(),
+          },
+        }),
+      );
+    });
+
+    socket.addEventListener("message", handleServerMessage);
+
+    socket.addEventListener("close", () => {
+      setConnectionState("disconnected");
+      socketRef.current = null;
+      if (stepRef.current === STEPS.PLAYING || stepRef.current === STEPS.WAITING) {
+        setErrorMessage("Conexión cerrada con el servidor.");
+        resetLocalState();
+        updateStep(STEPS.MODE);
+      }
+    });
+
+    socket.addEventListener("error", (event) => {
+      console.error("Error en la conexión WebSocket", event);
+      setErrorMessage("No se pudo establecer la conexión con el servidor.");
+    });
+  }, [action, handleServerMessage, password, roomCode, username, cleanupConnection, resetLocalState, updateStep]);
+
+  const handleUsernameSubmit = (event) => {
+    event.preventDefault();
+    if (!username.trim()) {
+      setErrorMessage("Ingresá un nombre de usuario.");
+      return;
+    }
+    setErrorMessage("");
+    updateStep(STEPS.MODE);
+  };
+
+  const handleRoomSubmit = (event) => {
+    event.preventDefault();
+    if (!roomCode.trim() || !password.trim()) {
+      setErrorMessage("Completá el código y la contraseña de la sala.");
+      return;
+    }
+    setErrorMessage("");
+    handleConnect();
+  };
+
+  const handleSelectMode = (selected) => {
+    setAction(selected);
+    updateStep(STEPS.ROOM);
+  };
+
+  const handleBackToMode = () => {
+    cleanupConnection();
+    resetLocalState();
+    setRoomCode("");
+    setPassword("");
+    setErrorMessage("");
+    updateStep(STEPS.MODE);
+  };
+
+  const handleLeaveRoom = () => {
+    sendMessage("leave_room", { code: roomCode.trim() });
+    cleanupConnection();
+    resetLocalState();
+    setRoomCode("");
+    setPassword("");
+    setStatusMessage("");
+    setErrorMessage("");
+    updateStep(STEPS.MODE);
+  };
+
+  const handleResetMatch = () => {
+    sendMessage("reset_game", { code: roomCode.trim() });
+  };
+
+  const handleMove = (index) => {
+    if (gameState.board[index] !== null) return;
+    sendMessage("make_move", { code: roomCode.trim(), index });
+  };
+
+  const handleReturnHome = () => {
+    handleLeaveRoom();
+    setUsername("");
+    setAction(null);
+    setStatusMessage("");
+    setErrorMessage("");
+    updateStep(STEPS.USERNAME);
+    onGoHome();
+  };
+
+  const isPlayerTurn = useMemo(
+    () =>
+      playerSymbol &&
+      gameState.turn === playerSymbol &&
+      gameState.winner === null &&
+      connectionState === "connected" &&
+      players.length === 2,
+    [connectionState, gameState.turn, gameState.winner, playerSymbol, players.length],
+  );
+
+  const currentOpponent = useMemo(() => {
+    if (players.length < 2) return opponentName;
+    const symbol = playerSymbolRef.current;
+    const opponent = players.find((player) => player.symbol !== symbol);
+    return opponent?.username ?? opponentName;
+  }, [opponentName, players]);
+
+  useEffect(() => {
+    if (!username) return;
+    const currentPlayer = players.find((player) => player.username === username);
+    if (currentPlayer && currentPlayer.symbol !== playerSymbolRef.current) {
+      playerSymbolRef.current = currentPlayer.symbol;
+      setPlayerSymbol(currentPlayer.symbol);
+    }
+  }, [players, username]);
+
+  return (
+    <section className="board online-board">
+      <header className="board-header">
+        <button type="button" onClick={handleReturnHome} className="secondary-button">
+          Volver al inicio
+        </button>
+        <h2>Juego online</h2>
+      </header>
+
+      {errorMessage && <div className="error-message">{errorMessage}</div>}
+      {statusMessage && <div className="status-message">{statusMessage}</div>}
+
+      {step === STEPS.USERNAME && (
+        <form className="form-card" onSubmit={handleUsernameSubmit}>
+          <label htmlFor="username">Nombre de usuario</label>
+          <input
+            id="username"
+            value={username}
+            onChange={(event) => setUsername(event.target.value)}
+            placeholder="Ingresá tu nombre"
+            required
+          />
+          <button type="submit">Continuar</button>
+        </form>
+      )}
+
+      {step === STEPS.MODE && (
+        <div className="mode-buttons inline">
+          <button type="button" className="mode-button" onClick={() => handleSelectMode("create")}>
+            Crear sala
+          </button>
+          <button type="button" className="mode-button" onClick={() => handleSelectMode("join")}>
+            Unirse a una sala
+          </button>
+        </div>
+      )}
+
+      {step === STEPS.ROOM && (
+        <form className="form-card" onSubmit={handleRoomSubmit}>
+          <label htmlFor="roomCode">Código de sala</label>
+          <input
+            id="roomCode"
+            value={roomCode}
+            onChange={(event) => setRoomCode(event.target.value.toUpperCase())}
+            placeholder="Ej: ARES01"
+            maxLength={10}
+            required
+          />
+
+          <label htmlFor="password">Contraseña</label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            placeholder="Contraseña de la sala"
+            required
+          />
+
+          <div className="form-actions">
+            <button type="button" className="secondary-button" onClick={handleBackToMode}>
+              Atrás
+            </button>
+            <button type="submit">{action === "create" ? "Crear" : "Unirse"}</button>
+          </div>
+        </form>
+      )}
+
+      {(step === STEPS.WAITING || step === STEPS.PLAYING) && (
+        <div className="online-wrapper">
+          <div className="online-meta">
+            <p>
+              <strong>Sala:</strong> {roomCode || "-"}
+            </p>
+            <p>
+              <strong>Conexión:</strong> {connectionState}
+            </p>
+            <p>
+              <strong>Vos:</strong> {username || "-"} {playerSymbol ? `(${TURN_ICONS[playerSymbol]})` : ""}
+            </p>
+            <p>
+              <strong>Rival:</strong> {currentOpponent || "Esperando jugador"}
+            </p>
+          </div>
+
+          <section className="game">
+            {gameState.board.map((square, index) => (
+              <Square
+                key={index}
+                index={index}
+                updateBoard={handleMove}
+                disabled={!isPlayerTurn}
+              >
+                {getIconForValue(square)}
+              </Square>
+            ))}
+          </section>
+
+          <section className="turn">
+            <Square isSelected={gameState.turn === TURNS.X} disabled>
+              {TURN_ICONS[TURNS.X]}
+            </Square>
+            <Square isSelected={gameState.turn === TURNS.O} disabled>
+              {TURN_ICONS[TURNS.O]}
+            </Square>
+          </section>
+
+          <div className="online-actions">
+            <button type="button" onClick={handleResetMatch} disabled={players.length < 2}>
+              Reiniciar partida
+            </button>
+            <button type="button" className="danger-button" onClick={handleLeaveRoom}>
+              Salir de la sala
+            </button>
+          </div>
+
+          {gameState.winner && (
+            <div className="winner-banner">
+              {gameState.winner === "draw"
+                ? "La partida terminó en empate."
+                : gameState.winner === playerSymbol
+                  ? "¡Ganaste la partida!"
+                  : "Tu rival ganó la partida."}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+OnlineGame.propTypes = {
+  onGoHome: PropTypes.func.isRequired,
+};

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -1,6 +1,11 @@
 export const TURNS = {
-  X: "❌",
-  O: "⚪",
+  X: "X",
+  O: "O",
+};
+
+export const TURN_ICONS = {
+  [TURNS.X]: "❌",
+  [TURNS.O]: "⚪",
 };
 
 export const winnerCombos = [
@@ -13,3 +18,27 @@ export const winnerCombos = [
   [0, 4, 8],
   [2, 4, 6],
 ];
+
+export const createEmptyBoard = () => Array(9).fill(null);
+
+export const checkWinner = (boardToCheck) => {
+  for (const combo of winnerCombos) {
+    const [a, b, c] = combo;
+    if (
+      boardToCheck[a] &&
+      boardToCheck[a] === boardToCheck[b] &&
+      boardToCheck[a] === boardToCheck[c]
+    ) {
+      return boardToCheck[a];
+    }
+  }
+  return null;
+};
+
+export const checkEndGame = (boardToCheck) =>
+  boardToCheck.every((square) => square !== null);
+
+export const getNextTurn = (turn) => (turn === TURNS.X ? TURNS.O : TURNS.X);
+
+export const getIconForValue = (value) =>
+  value && TURN_ICONS[value] ? TURN_ICONS[value] : value;

--- a/src/components/links.jsx
+++ b/src/components/links.jsx
@@ -9,19 +9,25 @@ export function Footer() {
       <a
         className="links"
         href="https://linkedin.com/in/thiago-javier-martins"
-        target="_blank">
+        target="_blank"
+        rel="noreferrer"
+      >
         <img src={linkedin} width={30} />
       </a>
       <a
         className="links"
         href="https://thiagomartins.vercel.app"
-        target="_blank">
+        target="_blank"
+        rel="noreferrer"
+      >
         <img src={portfolio} width={30} />
       </a>
       <a
         className="links"
         href="https://github.com/thiagojmartins"
-        target="_blank">
+        target="_blank"
+        rel="noreferrer"
+      >
         <img src={github} width={30} />
       </a>
     </footer>

--- a/src/components/square.jsx
+++ b/src/components/square.jsx
@@ -1,13 +1,43 @@
-export const Square = ({ children, isSelected, updateBoard, index }) => {
-  const className = `square ${isSelected ? "is-selected" : ""}`;
+import PropTypes from "prop-types";
+
+export const Square = ({
+  children,
+  isSelected,
+  updateBoard,
+  index,
+  disabled = false,
+}) => {
+  const className = `square ${isSelected ? "is-selected" : ""} ${
+    disabled ? "is-disabled" : ""
+  }`;
 
   const handleClick = () => {
+    if (disabled || typeof updateBoard !== "function") return;
     updateBoard(index);
   };
 
   return (
-    <div onClick={handleClick} className={className}>
+    <div
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      onClick={handleClick}
+      onKeyDown={(event) => {
+        if ((event.key === "Enter" || event.key === " ") && !disabled) {
+          event.preventDefault();
+          handleClick();
+        }
+      }}
+      className={className}
+    >
       {children}
     </div>
   );
+};
+
+Square.propTypes = {
+  children: PropTypes.node,
+  isSelected: PropTypes.bool,
+  updateBoard: PropTypes.func,
+  index: PropTypes.number,
+  disabled: PropTypes.bool,
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,31 +1,135 @@
+@import url("https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap");
+
 :root {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  color-scheme: dark;
+  font-family: "Outfit", system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
   font-size: 16px;
-  line-height: 24px;
+  line-height: 1.5;
   font-weight: 400;
+  letter-spacing: 0.01em;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  --color-background: #050315;
+  --color-surface: rgba(13, 19, 46, 0.65);
+  --color-surface-strong: rgba(19, 26, 56, 0.85);
+  --color-border: rgba(131, 146, 255, 0.45);
+  --color-border-strong: rgba(131, 146, 255, 0.75);
+  --color-text: #f5f7ff;
+  --color-text-muted: rgba(245, 247, 255, 0.7);
+  --color-text-subtle: rgba(245, 247, 255, 0.5);
+  --color-accent: #7b5cff;
+  --color-accent-secondary: #00e5ff;
+  --color-accent-soft: rgba(0, 229, 255, 0.14);
+  --color-accent-strong: rgba(123, 92, 255, 0.85);
+  --color-danger: #ff5c7a;
+  --shadow-lg: 0 30px 80px -48px rgba(0, 229, 255, 0.65),
+    0 26px 60px -50px rgba(123, 92, 255, 0.85);
+  --shadow-md: 0 18px 50px -30px rgba(0, 229, 255, 0.3),
+    0 10px 30px -20px rgba(123, 92, 255, 0.35);
+  --shadow-soft: 0 12px 32px -22px rgba(123, 92, 255, 0.4);
+}
 
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
+@keyframes aurora {
+  0% {
+    transform: translate3d(-10%, -10%, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(10%, 5%, 0) scale(1.12);
+  }
+  100% {
+    transform: translate3d(-12%, 8%, 0) scale(1);
+  }
+}
+
+@keyframes sparkle {
+  0% {
+    opacity: 0.1;
+    transform: translateY(0) scale(1);
+  }
+  50% {
+    opacity: 0.4;
+    transform: translateY(-6px) scale(1.05);
+  }
+  100% {
+    opacity: 0.1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes float {
+  0% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  min-width: 320px;
   min-height: 100vh;
+  min-width: 320px;
+  background: radial-gradient(circle at top right, #0c1540 0%, transparent 45%),
+    radial-gradient(circle at 20% 120%, rgba(0, 229, 255, 0.2) 0%, transparent 45%),
+    var(--color-background);
+  color: var(--color-text);
+  position: relative;
+  overflow-x: hidden;
 }
 
-* {
-  padding: 0;
-  margin: 0;
-  box-sizing: border-box;
+body::before {
+  content: "";
+  position: fixed;
+  inset: -40%;
+  background: conic-gradient(
+    from 120deg,
+    rgba(0, 229, 255, 0.28),
+    rgba(123, 92, 255, 0.22),
+    rgba(255, 104, 196, 0.16),
+    rgba(0, 229, 255, 0.28)
+  );
+  filter: blur(120px);
+  opacity: 0.7;
+  animation: aurora 18s ease-in-out infinite;
+  z-index: -2;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(
+      rgba(255, 255, 255, 0.12) 1px,
+      transparent 1px
+    ),
+    radial-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px);
+  background-size: 120px 120px, 80px 80px;
+  background-position: 20px 40px, -40px -20px;
+  opacity: 0.25;
+  animation: sparkle 10s linear infinite;
+  z-index: -3;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+}
+
+main,
+button,
+input,
+textarea {
+  font: inherit;
+  color: inherit;
 }
 
 .app-shell {
@@ -34,290 +138,172 @@ body {
   align-items: center;
   justify-content: space-between;
   min-height: 100vh;
-  padding-bottom: 40px;
-}
-
-.board {
-  width: min(520px, 90vw);
-  margin: 40px auto 0;
-  text-align: center;
-}
-
-.board h1 {
-  font-size: 30px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #eee;
-}
-
-.board button {
-  padding: 8px 12px;
-  margin: 20px auto;
-  background: transparent;
-  border: 2px solid #eee;
-  color: #eee;
-  min-width: 140px;
-  border-radius: 5px;
-  transition: 0.2s;
-  font-weight: bold;
-  cursor: pointer;
-}
-
-.board button:hover {
-  background: #eee;
-  color: #222;
-}
-
-.board button.toggle-button {
-  min-width: 120px;
-}
-
-.board button.toggle-button.is-active {
-  background: #09f;
-  color: #fff;
-  border-color: #09f;
-}
-
-.board button.toggle-button.is-active:hover {
-  background: #09f;
-  color: #fff;
-}
-
-.board .game {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 10px;
-}
-
-.turn {
-  display: flex;
-  justify-content: center;
-  margin: 15px auto;
-  width: fit-content;
+  padding: 40px 16px 60px;
+  gap: 24px;
   position: relative;
-  border-radius: 10px;
 }
 
-.turn .square,
-.winner .square {
-  width: 50px;
-  height: 50px;
-  font-size: 30px;
-  pointer-events: none;
-  border-color: transparent;
-}
-
-.square.is-selected {
-  color: #fff;
-  background: #09f;
-}
-
-.winner {
+.app-shell::before {
+  content: "";
   position: absolute;
-  width: 100vw;
-  height: 100vh;
-  top: 0;
-  left: 0;
-  display: grid;
-  place-items: center;
-  background-color: rgba(0, 0, 0, 0.7);
+  inset: 40px 20px 80px;
+  border-radius: 32px;
+  background: linear-gradient(
+      135deg,
+      rgba(123, 92, 255, 0.14),
+      rgba(0, 229, 255, 0.08)
+    ),
+    rgba(8, 11, 30, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  filter: blur(0);
+  z-index: -1;
 }
 
-.winner .text {
-  background: #111;
-  height: 300px;
-  width: 320px;
-  border: 2px solid #eee;
-  border-radius: 10px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: 20px;
+h1,
+h2,
+h3 {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
 }
 
-.winner .win {
-  margin: 0 auto;
-  width: fit-content;
-  border: 2px solid #eee;
-  border-radius: 10px;
-  display: flex;
-  gap: 15px;
-}
-
-.square {
-  width: 60px;
-  height: 60px;
-  border: 2px solid #eee;
-  border-radius: 5px;
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  font-size: 30px;
-}
-
-.square.is-disabled {
-  cursor: not-allowed;
-  pointer-events: none;
-}
-
-.square:focus {
-  outline: 2px solid #09f;
-  outline-offset: 2px;
-}
-
-.footer {
-  margin-top: 60px;
-}
-
-.footer .links {
-  padding: 20px;
-}
-
-.board-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 10px;
-}
-
-.secondary-button {
-  border: 2px solid #eee;
-  background: transparent;
-  color: #eee;
-  font-weight: 600;
-  border-radius: 5px;
-  padding: 6px 12px;
-  cursor: pointer;
-  transition: 0.2s;
-}
-
-.secondary-button:hover {
-  background: #eee;
-  color: #222;
-}
-
-.danger-button {
-  border: 2px solid #ff4d4f;
-  color: #ff4d4f;
-  background: transparent;
-}
-
-.danger-button:hover {
-  background: #ff4d4f;
-  color: #111;
-}
-
-.status-message,
-.error-message {
-  margin: 10px auto;
-  padding: 12px 16px;
-  border-radius: 6px;
-  max-width: 520px;
-  text-align: center;
-}
-
-.status-message {
-  background: rgba(0, 153, 255, 0.1);
-  border: 1px solid rgba(0, 153, 255, 0.4);
-}
-
-.error-message {
-  background: rgba(255, 77, 79, 0.15);
-  border: 1px solid rgba(255, 77, 79, 0.6);
-}
-
-.form-card {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  margin: 20px auto 0;
-  padding: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 10px;
-  background: rgba(0, 0, 0, 0.3);
-  width: min(360px, 90vw);
-}
-
-.form-card label {
-  font-weight: 600;
-  text-align: left;
-}
-
-.form-card input {
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 6px;
-  padding: 10px 12px;
-  color: #eee;
-}
-
-.form-card input:focus {
-  outline: 2px solid #09f;
-  border-color: transparent;
-}
-
-.form-card button {
-  margin: 10px 0 0;
-}
-
-.form-actions {
-  display: flex;
-  gap: 12px;
-  justify-content: flex-end;
-}
-
-.home-screen {
-  width: min(520px, 90vw);
-  margin-top: 60px;
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-.home-screen h1 {
-  font-size: 2.5rem;
+p {
   margin: 0;
 }
 
+a {
+  color: inherit;
+}
+
+.home-screen {
+  width: min(600px, 92vw);
+  margin-top: 50px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  padding: 32px 28px 40px;
+  border-radius: 32px;
+  background: linear-gradient(
+      150deg,
+      rgba(123, 92, 255, 0.12),
+      rgba(0, 229, 255, 0.08)
+    ),
+    rgba(8, 11, 30, 0.65);
+  border: 1px solid var(--color-border);
+  backdrop-filter: blur(22px);
+  box-shadow: var(--shadow-lg);
+  position: relative;
+  overflow: hidden;
+}
+
+.home-screen::before,
+.home-screen::after {
+  content: "";
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(0, 229, 255, 0.4), transparent 70%);
+  filter: blur(60px);
+  opacity: 0.5;
+  z-index: -1;
+}
+
+.home-screen::before {
+  top: -120px;
+  right: -100px;
+}
+
+.home-screen::after {
+  bottom: -160px;
+  left: -80px;
+  background: radial-gradient(
+    circle,
+    rgba(123, 92, 255, 0.35),
+    transparent 70%
+  );
+}
+
+.home-logo {
+  margin: 0 auto;
+  filter: drop-shadow(0 12px 25px rgba(0, 229, 255, 0.25));
+  animation: float 5s ease-in-out infinite;
+}
+
+.home-screen h1 {
+  font-size: clamp(2.4rem, 4vw, 3rem);
+}
+
 .home-subtitle {
-  line-height: 1.6;
-  color: rgba(255, 255, 255, 0.8);
+  line-height: 1.7;
+  color: var(--color-text-muted);
 }
 
 .mode-buttons {
   display: flex;
   flex-direction: column;
   gap: 16px;
-  margin-top: 10px;
-}
-
-.mode-buttons.inline {
-  flex-direction: row;
-  justify-content: center;
+  margin-top: 12px;
 }
 
 .mode-button {
+  position: relative;
+  border: none;
+  border-radius: 20px;
+  padding: 20px 24px;
+  cursor: pointer;
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 14px 18px;
-  border-radius: 8px;
-  border: 2px solid rgba(255, 255, 255, 0.4);
-  background: rgba(0, 0, 0, 0.3);
-  color: #eee;
-  cursor: pointer;
-  transition: transform 0.2s, border-color 0.2s, background 0.2s;
-  min-width: 180px;
+  text-align: left;
+  color: var(--color-text);
+  overflow: hidden;
+  isolation: isolate;
+  background: rgba(10, 12, 32, 0.6);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
-.mode-button:hover {
-  transform: translateY(-2px);
-  border-color: #09f;
-  background: rgba(0, 153, 255, 0.15);
+.mode-button::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  background: linear-gradient(
+    135deg,
+    rgba(0, 229, 255, 0.9),
+    rgba(123, 92, 255, 0.95),
+    rgba(255, 95, 173, 0.85)
+  );
+  z-index: -2;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.mode-button::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+      145deg,
+      rgba(123, 92, 255, 0.18),
+      rgba(0, 229, 255, 0.14)
+    ),
+    rgba(10, 12, 32, 0.75);
+  z-index: -1;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.mode-button:hover,
+.mode-button:focus-visible {
+  transform: translateY(-6px) scale(1.01);
+  box-shadow: var(--shadow-md);
+}
+
+.mode-button:hover::before,
+.mode-button:focus-visible::before {
+  opacity: 0.7;
 }
 
 .mode-title {
@@ -326,42 +312,409 @@ body {
 }
 
 .mode-description {
-  font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
 }
 
 .home-icons {
   display: flex;
-  gap: 14px;
+  gap: 18px;
   justify-content: center;
   font-size: 1.8rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--color-text-subtle);
+}
+
+.board {
+  position: relative;
+  width: min(640px, 92vw);
+  margin: 50px auto 0;
+  padding: 32px 30px 46px;
+  text-align: center;
+  border-radius: 32px;
+  background: linear-gradient(
+      160deg,
+      rgba(123, 92, 255, 0.12),
+      rgba(0, 229, 255, 0.08)
+    ),
+    rgba(8, 11, 30, 0.68);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(20px);
+  overflow: hidden;
+}
+
+.board::after {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: 26px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  pointer-events: none;
+}
+
+.board h2 {
+  font-size: clamp(1.7rem, 3vw, 2rem);
+}
+
+.board button {
+  padding: 12px 22px;
+  margin: 24px auto 0;
+  background: linear-gradient(
+      140deg,
+      rgba(0, 229, 255, 0.18),
+      rgba(123, 92, 255, 0.18)
+    ),
+    rgba(8, 10, 30, 0.6);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  min-width: 160px;
+  border-radius: 999px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease,
+    border-color 0.2s ease, background 0.2s ease;
+  font-weight: 600;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+}
+
+.board button::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background: linear-gradient(
+    120deg,
+    rgba(0, 229, 255, 0.45),
+    rgba(123, 92, 255, 0.45)
+  );
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: -1;
+}
+
+.board button:hover,
+.board button:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-soft);
+  border-color: var(--color-border-strong);
+}
+
+.board button:hover::before,
+.board button:focus-visible::before {
+  opacity: 0.6;
+}
+
+.board button.toggle-button {
+  min-width: 130px;
+  margin: 0;
+}
+
+.board button.toggle-button.is-active {
+  color: var(--color-text);
+  background: linear-gradient(135deg, #7b5cff, #00e5ff);
+  box-shadow: 0 18px 42px -24px rgba(123, 92, 255, 0.9);
+  border-color: transparent;
+}
+
+.board button.toggle-button.is-active::before {
+  opacity: 0;
+}
+
+.board button.toggle-button.is-active:hover {
+  transform: translateY(-2px);
+}
+
+.board .game {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 32px;
+  padding: 28px;
+  border-radius: 28px;
+  background: linear-gradient(
+      135deg,
+      rgba(123, 92, 255, 0.14),
+      rgba(0, 229, 255, 0.1)
+    ),
+    rgba(10, 12, 32, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.square {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 24px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  font-weight: 600;
+  color: var(--color-text);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(
+      145deg,
+      rgba(123, 92, 255, 0.12),
+      rgba(0, 229, 255, 0.08)
+    ),
+    rgba(15, 18, 46, 0.8);
+  transition: transform 0.2s ease, box-shadow 0.2s ease,
+    background 0.3s ease, border-color 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.square::after {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.square:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 40px -30px rgba(123, 92, 255, 0.8);
+  border-color: rgba(123, 92, 255, 0.6);
+}
+
+.square:hover::after {
+  opacity: 0.7;
+}
+
+.square.is-selected {
+  background: linear-gradient(135deg, rgba(123, 92, 255, 0.9), rgba(0, 229, 255, 0.9));
+  box-shadow: 0 26px 60px -30px rgba(0, 229, 255, 0.9);
+  border-color: transparent;
+}
+
+.square.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  transform: none;
+  box-shadow: none;
+}
+
+.square:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(123, 92, 255, 0.6);
+}
+
+.turn {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  margin: 26px auto 0;
+  padding: 12px 18px;
+  border-radius: 999px;
+  background: rgba(10, 12, 32, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.turn .square,
+.winner .square {
+  width: 60px;
+  height: 60px;
+  font-size: 1.8rem;
+  border-radius: 18px;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+}
+
+.turn .square.is-selected {
+  background: linear-gradient(135deg, rgba(123, 92, 255, 0.85), rgba(0, 229, 255, 0.85));
+  border: none;
+  box-shadow: none;
+}
+
+.status-message,
+.error-message {
+  margin: 18px auto 0;
+  padding: 14px 18px;
+  border-radius: 16px;
+  max-width: 520px;
+  text-align: center;
+  font-weight: 500;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(12px);
+}
+
+.status-message {
+  background: rgba(0, 229, 255, 0.12);
+  color: var(--color-text);
+}
+
+.error-message {
+  background: rgba(255, 92, 122, 0.15);
+  border-color: rgba(255, 92, 122, 0.55);
+  color: #ffe5eb;
+}
+
+.board-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.secondary-button {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(10, 12, 32, 0.6);
+  color: var(--color-text);
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 10px 18px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease,
+    border-color 0.2s ease, background 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.secondary-button:hover,
+.secondary-button:focus-visible {
+  transform: translateY(-3px);
+  border-color: var(--color-border-strong);
+  box-shadow: var(--shadow-soft);
+}
+
+.danger-button {
+  border: 1px solid rgba(255, 92, 122, 0.6);
+  color: #ffe5eb;
+  background: rgba(255, 92, 122, 0.12);
+}
+
+.danger-button:hover,
+.danger-button:focus-visible {
+  background: rgba(255, 92, 122, 0.2);
+  border-color: rgba(255, 92, 122, 0.85);
+}
+
+.winner {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  backdrop-filter: blur(20px);
+  background: rgba(3, 4, 12, 0.7);
+  z-index: 10;
+  padding: 20px;
+}
+
+.winner .text {
+  background: linear-gradient(
+      140deg,
+      rgba(123, 92, 255, 0.12),
+      rgba(0, 229, 255, 0.12)
+    ),
+    rgba(8, 11, 30, 0.9);
+  min-height: 280px;
+  width: min(360px, 92vw);
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 18px;
+  padding: 28px;
+  box-shadow: var(--shadow-md);
+}
+
+.winner .win {
+  width: fit-content;
+  border-radius: 20px;
+  padding: 12px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  display: flex;
+  gap: 14px;
+  background: rgba(10, 12, 32, 0.6);
+}
+
+.winner button {
+  margin-top: 6px;
+}
+
+.winner h2 {
+  font-size: 1.6rem;
 }
 
 .online-wrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
-  margin-top: 20px;
+  gap: 18px;
+  margin-top: 22px;
+}
+
+.form-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin: 20px auto 0;
+  padding: 24px 22px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 22px;
+  background: rgba(8, 11, 30, 0.7);
+  backdrop-filter: blur(16px);
+  width: min(400px, 92vw);
+  box-shadow: var(--shadow-md);
+}
+
+.form-card label {
+  font-weight: 600;
+  text-align: left;
+}
+
+.form-card input {
+  background: rgba(12, 14, 36, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  padding: 12px 14px;
+  color: var(--color-text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-card input:focus {
+  outline: none;
+  border-color: var(--color-border-strong);
+  box-shadow: 0 0 0 3px rgba(123, 92, 255, 0.4);
+}
+
+.form-card button {
+  margin: 12px 0 0;
+}
+
+.form-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
 }
 
 .online-meta {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 8px 20px;
+  gap: 12px 18px;
   width: 100%;
   text-align: left;
-  background: rgba(0, 0, 0, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 10px;
-  padding: 16px;
+  background: rgba(8, 11, 30, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 22px;
+  padding: 18px;
+  backdrop-filter: blur(16px);
 }
 
 .online-actions {
   display: flex;
   gap: 12px;
   justify-content: center;
+  flex-wrap: wrap;
 }
 
 .online-actions button {
@@ -369,25 +722,31 @@ body {
 }
 
 .winner-banner {
-  margin-top: 10px;
-  padding: 10px 18px;
-  border-radius: 6px;
-  background: rgba(0, 0, 0, 0.4);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  margin-top: 16px;
+  padding: 14px 18px;
+  border-radius: 18px;
+  background: rgba(10, 12, 32, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: var(--shadow-soft);
 }
 
 .bot-settings {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
   align-items: center;
-  margin: 10px auto 20px;
+  margin: 16px auto 26px;
+  padding: 18px;
+  border-radius: 24px;
+  background: rgba(10, 12, 32, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(12px);
 }
 
 .bot-setting-group {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
   align-items: center;
 }
 
@@ -404,6 +763,84 @@ body {
 
 .bot-settings-note {
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--color-text-subtle);
   margin-top: 4px;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 18px 26px;
+  border-radius: 999px;
+  background: rgba(8, 11, 30, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(16px);
+}
+
+.footer p {
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+
+.footer .links {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: rgba(10, 12, 32, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: transform 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.footer .links:hover,
+.footer .links:focus-visible {
+  transform: translateY(-3px);
+  border-color: rgba(123, 92, 255, 0.8);
+  box-shadow: 0 12px 24px -18px rgba(123, 92, 255, 0.9);
+}
+
+.footer img {
+  width: 24px;
+  height: 24px;
+  filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.4));
+}
+
+@media (min-width: 768px) {
+  .mode-buttons {
+    flex-direction: row;
+  }
+
+  .mode-button {
+    flex: 1;
+  }
+
+  .board {
+    padding: 40px 40px 54px;
+  }
+
+  .board .game {
+    gap: 18px;
+  }
+
+  .turn .square,
+  .winner .square {
+    width: 70px;
+    height: 70px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -18,8 +18,6 @@
 
 body {
   margin: 0;
-  display: flex;
-  justify-content: center;
   min-width: 320px;
   min-height: 100vh;
 }
@@ -30,9 +28,18 @@ body {
   box-sizing: border-box;
 }
 
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 100vh;
+  padding-bottom: 40px;
+}
+
 .board {
-  width: fit-content;
-  margin: 40px 0px 0px 0px;
+  width: min(520px, 90vw);
+  margin: 40px auto 0;
   text-align: center;
 }
 
@@ -46,11 +53,11 @@ body {
 
 .board button {
   padding: 8px 12px;
-  margin: 25px;
+  margin: 20px auto;
   background: transparent;
   border: 2px solid #eee;
   color: #eee;
-  width: 100px;
+  min-width: 140px;
   border-radius: 5px;
   transition: 0.2s;
   font-weight: bold;
@@ -135,10 +142,221 @@ body {
   font-size: 30px;
 }
 
+.square.is-disabled {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.square:focus {
+  outline: 2px solid #09f;
+  outline-offset: 2px;
+}
+
 .footer {
   margin-top: 60px;
 }
 
 .footer .links {
   padding: 20px;
+}
+
+.board-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.secondary-button {
+  border: 2px solid #eee;
+  background: transparent;
+  color: #eee;
+  font-weight: 600;
+  border-radius: 5px;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+.secondary-button:hover {
+  background: #eee;
+  color: #222;
+}
+
+.danger-button {
+  border: 2px solid #ff4d4f;
+  color: #ff4d4f;
+  background: transparent;
+}
+
+.danger-button:hover {
+  background: #ff4d4f;
+  color: #111;
+}
+
+.status-message,
+.error-message {
+  margin: 10px auto;
+  padding: 12px 16px;
+  border-radius: 6px;
+  max-width: 520px;
+  text-align: center;
+}
+
+.status-message {
+  background: rgba(0, 153, 255, 0.1);
+  border: 1px solid rgba(0, 153, 255, 0.4);
+}
+
+.error-message {
+  background: rgba(255, 77, 79, 0.15);
+  border: 1px solid rgba(255, 77, 79, 0.6);
+}
+
+.form-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 20px auto 0;
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.3);
+  width: min(360px, 90vw);
+}
+
+.form-card label {
+  font-weight: 600;
+  text-align: left;
+}
+
+.form-card input {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  padding: 10px 12px;
+  color: #eee;
+}
+
+.form-card input:focus {
+  outline: 2px solid #09f;
+  border-color: transparent;
+}
+
+.form-card button {
+  margin: 10px 0 0;
+}
+
+.form-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.home-screen {
+  width: min(520px, 90vw);
+  margin-top: 60px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.home-screen h1 {
+  font-size: 2.5rem;
+  margin: 0;
+}
+
+.home-subtitle {
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.mode-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 10px;
+}
+
+.mode-buttons.inline {
+  flex-direction: row;
+  justify-content: center;
+}
+
+.mode-button {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 18px;
+  border-radius: 8px;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  background: rgba(0, 0, 0, 0.3);
+  color: #eee;
+  cursor: pointer;
+  transition: transform 0.2s, border-color 0.2s, background 0.2s;
+  min-width: 180px;
+}
+
+.mode-button:hover {
+  transform: translateY(-2px);
+  border-color: #09f;
+  background: rgba(0, 153, 255, 0.15);
+}
+
+.mode-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.mode-description {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.home-icons {
+  display: flex;
+  gap: 14px;
+  justify-content: center;
+  font-size: 1.8rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.online-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  margin-top: 20px;
+}
+
+.online-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px 20px;
+  width: 100%;
+  text-align: left;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  padding: 16px;
+}
+
+.online-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.online-actions button {
+  margin: 0;
+}
+
+.winner-banner {
+  margin-top: 10px;
+  padding: 10px 18px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.2);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -69,6 +69,21 @@ body {
   color: #222;
 }
 
+.board button.toggle-button {
+  min-width: 120px;
+}
+
+.board button.toggle-button.is-active {
+  background: #09f;
+  color: #fff;
+  border-color: #09f;
+}
+
+.board button.toggle-button.is-active:hover {
+  background: #09f;
+  color: #fff;
+}
+
 .board .game {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -359,4 +374,36 @@ body {
   border-radius: 6px;
   background: rgba(0, 0, 0, 0.4);
   border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.bot-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+  margin: 10px auto 20px;
+}
+
+.bot-setting-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+}
+
+.bot-settings .toggle-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+}
+
+.bot-settings button {
+  margin: 0;
+}
+
+.bot-settings-note {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+  margin-top: 4px;
 }


### PR DESCRIPTION
## Summary
- add a home screen to select local, online or solo play modes and refactor the app shell
- implement solo bot AI and an online flow with WebSocket-backed lobby, matchmaking and synced boards
- create a Node WebSocket server, refresh styling, and document the new scripts and setup

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccb0a214b0832eab81e50725d960aa